### PR TITLE
Checked Accessibility of Portfolio website

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Jay Melfah</title>
+  <title>Jay Melfah's Portfolio</title>
   <link rel="stylesheet" href="./style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -324,8 +324,10 @@
         so if you'd like to chat please get in.
       </p>
       <form id="forms" action="https://formspree.io/f/mayknqjr" method="post">
+        <label class="form_label_name" for="fullname">Fullname</label>
         <input class="fullname" type="text" name="fullname" placeholder="Full name" maxlength="30" required>
-        <input class="email" type="email" name="email" placeholder="Email address" required>
+        <label class="form_label_email" for="email">Email</label>
+        <input class="email" type="email" name="email" placeholder="Email address" required> 
         <textarea class="textbox" name="message" placeholder="Enter text here" maxlength="500" required></textarea>
         <button class="intouch" type="submit">Get in touch</button>
       </form>

--- a/index.html
+++ b/index.html
@@ -324,9 +324,9 @@
         so if you'd like to chat please get in.
       </p>
       <form id="forms" action="https://formspree.io/f/mayknqjr" method="post">
-        <label class="form_label_name" for="fullname">Fullname</label>
+        <label class="form_label_name">Fullname</label>
         <input class="fullname" type="text" name="fullname" placeholder="Full name" maxlength="30" required>
-        <label class="form_label_email" for="email">Email</label>
+        <label class="form_label_email">Email</label>
         <input class="email" type="email" name="email" placeholder="Email address" required> 
         <textarea class="textbox" name="message" placeholder="Enter text here" maxlength="500" required></textarea>
         <button class="intouch" type="submit">Get in touch</button>

--- a/style.css
+++ b/style.css
@@ -2235,3 +2235,11 @@ textarea::placeholder {
     height: 100%;
   }
 }
+
+.form_label_name {
+  display: none;
+}
+
+.form_label_email {
+  display: none;
+}


### PR DESCRIPTION
This is a report of all the checks done on the portfolio website to ascertain accessibility:

Page titles- Page title was not descriptive of the page content. This was changed. The link is below:
[https://github.com/Jaymelfah/Mobile-Portfolio/blob/24233cee8744a1c3677e1d17bd3839cefc507a4d/index.html#L8](url)

Image text alternatives- No issues found
Text Headings- No issues found
Color contrast- No issues found
Resize- No issues found

Interaction- Labels were not found in the form section. Labels were added to enhance accessibility for voice overs. The link is shown below:
 [https://github.com/Jaymelfah/Mobile-Portfolio/blob/Accessiblity-checks/index.html#L327-L330](url)


Moving Content- No issues found
Multimedia- No issues found
Structure- No issues found
